### PR TITLE
Add Docker compose build

### DIFF
--- a/src/class/docker.js
+++ b/src/class/docker.js
@@ -22,7 +22,7 @@ export default class Docker {
 
   async buildCompose(){
     try{
-      const cmd = `docker compose -f ${this.path}/docker-compose.yml up -d`
+      const cmd = `docker-compose -f ${this.path}/docker-compose.yml up -d`
       Log.info(`Docker Compose Build - ${cmd}`)
       await execSync(cmd, { stdio: 'ignore' })
       return true

--- a/src/class/docker.js
+++ b/src/class/docker.js
@@ -22,6 +22,9 @@ export default class Docker {
 
   async buildCompose(){
     try{
+
+      this.path = this.path.toLowerCase().replaceAll(/[^\w\s]/g, '_')
+
       const cmd = `docker-compose -f ${this.path}/docker-compose.yml up -d`
       Log.info(`Docker Compose Build - ${cmd}`)
       await execSync(cmd, { stdio: 'ignore' })

--- a/src/class/docker.js
+++ b/src/class/docker.js
@@ -48,9 +48,6 @@ export default class Docker {
   async getPort() {
     const containers = await Docker.ps()
     const container = containers.filter(container => container[0] === this.id)[0]
-
-    console.log(container)
-
     const port = container[5].split('->')[0].split(':')[1]
     Log.success(`Link\n- http://localhost:${port}\n- localhost ${port}`)
 

--- a/src/class/docker.js
+++ b/src/class/docker.js
@@ -48,6 +48,9 @@ export default class Docker {
   async getPort() {
     const containers = await Docker.ps()
     const container = containers.filter(container => container[0] === this.id)[0]
+
+    console.log(container)
+
     const port = container[5].split('->')[0].split(':')[1]
     Log.success(`Link\n- http://localhost:${port}\n- localhost ${port}`)
 

--- a/src/class/docker.js
+++ b/src/class/docker.js
@@ -22,9 +22,6 @@ export default class Docker {
 
   async buildCompose(){
     try{
-
-      this.path = this.path.toLowerCase().replaceAll(/[^\w\s]/g, '_')
-
       const cmd = `docker-compose -f ${this.path}/docker-compose.yml up -d`
       Log.info(`Docker Compose Build - ${cmd}`)
       await execSync(cmd, { stdio: 'ignore' })

--- a/src/class/docker.js
+++ b/src/class/docker.js
@@ -19,6 +19,18 @@ export default class Docker {
       return false
     }
   }
+
+  async buildCompose(){
+    try{
+      const cmd = `docker compose -f ${this.path}/docker-compose.yml up -d`
+      Log.info(`Docker Compose Build - ${cmd}`)
+      await execSync(cmd, { stdio: 'ignore' })
+      return true
+    } catch (err) {
+      Log.error(`Docker Compose Build Error: ${err}`)
+      return false
+    }
+  }
   
   async run() {
     const cmd = `docker run -dP ${this.name}`

--- a/src/class/docker.js
+++ b/src/class/docker.js
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process'
-
+import fs from "fs"
 import Log from '../util/log.js'
 
 export default class Docker {
@@ -21,14 +21,19 @@ export default class Docker {
   }
 
   async buildCompose(){
-    try{
-      const cmd = `docker-compose -f ${this.path}/docker-compose.yml up -d`
-      Log.info(`Docker Compose Build - ${cmd}`)
-      await execSync(cmd, { stdio: 'ignore' })
-      return true
-    } catch (err) {
-      Log.error(`Docker Compose Build Error: ${err}`)
-      return false
+    if (fs.existsSync(`${this.path}/docker-compose.yml`)){
+      try{
+        const cmd = `docker-compose -f ${this.path}/docker-compose.yml up -d`
+        Log.info(`Docker Compose Build - ${cmd}`)
+        await execSync(cmd, { stdio: 'ignore' })
+        return true
+      } catch (err) {
+        Log.error(`Docker Compose Build Error: ${err}`)
+        return false
+      }
+    }
+    else {
+      Log.error(`Not found Docker Compose file at ${this.path}/docker-compose.yml`)
     }
   }
   

--- a/src/command/create.js
+++ b/src/command/create.js
@@ -60,7 +60,6 @@ export default async function create(wargameLink) {
     const buildSuccess = await docker.buildCompose();
     (buildSuccess) ? Log.success('Docker Compose Build Success') : Log.error('Docker Compose Build Fail')
     if (buildSuccess) {
-      await docker.run()
       await docker.getPort()
     } else {
       process.exit(1)

--- a/src/command/create.js
+++ b/src/command/create.js
@@ -60,7 +60,8 @@ export default async function create(wargameLink) {
     const buildSuccess = await docker.buildCompose();
     (buildSuccess) ? Log.success('Docker Compose Build Success') : Log.error('Docker Compose Build Fail')
     if (buildSuccess) {
-      await docker.getPort()
+      // Todo - Fix getPort
+      // await docker.getPort()
     } else {
       process.exit(1)
     }

--- a/src/command/create.js
+++ b/src/command/create.js
@@ -55,6 +55,16 @@ export default async function create(wargameLink) {
     } else {
       process.exit(1)
     }
+  } else if (args['c'] || args['compose']) {
+    const docker = new Docker(wargame.name, `./${wargame.name}`)
+    const buildSuccess = await docker.buildCompose();
+    (buildSuccess) ? Log.success('Docker Compose Build Success') : Log.error('Docker Compose Build Fail')
+    if (buildSuccess) {
+      await docker.run()
+      await docker.getPort()
+    } else {
+      process.exit(1)
+    }
   }
 
   console.log()


### PR DESCRIPTION
Web 문제에서 여러개의 container 들이 동작하는 환경의 문제일때, `docker-compose.yml` 파일이 제공되는 경우가 있습니다.
해당 경우에서는 `docker-compose.yml` 파일을 빌드시켜 한번에 필요한 환경이 구축되도록 구현합니다.

다만, docker compose로 빌드하였을때 빌드된 컨테이너의 id를 구할 수 없어 getPort 기능이 제대로 동작하지 않는 이슈와 `https://dreamhack.io/wargame/challenges/678` 와 같이 문제 제목의 `:` 때문에 빌드가 잘되지 않는 이슈가 존재하여 해당 부분을 추후에 수정해야 할 것 같습니다.

# Example
```bash
dh create https://dreamhack.io/wargame/challenges/640 -c
```

```
[*] Wargame Name - narrow_Date
[*] Wargame Downloaded
[*] Wargame Extracted
[*] Wargame Zip File Removed
[*] Docker Compose Build - docker-compose -f ./narrow_Date/docker-compose.yml up -d
[+] Docker Compose Build Success
```

---

```bash
dh create https://dreamhack.io/wargame/challenges/1090 -c
```

```
[*] Wargame Name - dreamhack-cli
[*] Wargame Downloaded
[*] Wargame Extracted
[*] Wargame Zip File Removed
[-] Not found Docker Compose file at ./dreamhack-cli/docker-compose.yml
[-] Docker Compose Build Fail
```
